### PR TITLE
fix: replace password authentication with personal access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # 1990
 
-Make your Github history back to 1990.
+Make your GitHub history back to 1990.
 
 ![image](https://user-images.githubusercontent.com/11247099/89427797-38f24f80-d76e-11ea-84fa-ab5642751792.png)
 
 ## Travel Back
 
-[Create a new repo](https://github.com/new) named `1990` on Github.
+[Create a new repo](https://github.com/new) named `1990` on GitHub.
+
+[Generate a personal access token](https://github.com/settings/tokens/new) on GitHub and copy it.
 
 Run the following script
 
@@ -14,7 +16,7 @@ Run the following script
 $ sh -c "$(curl -fsSL https://raw.github.com/antfu/1990-script/master/index.sh)"
 ```
 
-Enter you Github username and you are done :)
+Enter you GitHub username and access token and then you are done :)
 
 ## Explanations
 

--- a/index.sh
+++ b/index.sh
@@ -2,10 +2,13 @@
 
 _() {
   YEAR="1990"
-  echo "Github Username: "
+  echo "GitHub Username: "
   read -r USERNAME
+  echo "GitHub Access token: "
+  read -r ACCESS_TOKEN
 
   [ -z "$USERNAME" ] && exit 1
+  [ -z "$ACCESS_TOKEN" ] && exit 1  
   [ ! -d $YEAR ] && mkdir $YEAR
 
   cd "${YEAR}" || exit
@@ -16,7 +19,7 @@ _() {
   GIT_AUTHOR_DATE="${YEAR}-01-01T18:00:00" \
     GIT_COMMITTER_DATE="${YEAR}-01-01T18:00:00" \
     git commit -m "${YEAR}"
-  git remote add origin "https://github.com/${USERNAME}/${YEAR}.git"
+  git remote add origin "https://${ACCESS_TOKEN}@github.com/${USERNAME}/${YEAR}.git"
   git branch -M main
   git push -u origin main -f
   cd ..


### PR DESCRIPTION
The following error occurs when executing the script：
> remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.

So, obviously something needs to be changed.